### PR TITLE
import missing trace_tool

### DIFF
--- a/examples/llamaindex_examples/react_agent.ipynb
+++ b/examples/llamaindex_examples/react_agent.ipynb
@@ -70,6 +70,7 @@
     "from ragaai_catalyst.tracers import Tracer\n",
     "from ragaai_catalyst import RagaAICatalyst, init_tracing\n",
     "from ragaai_catalyst import trace_llm\n",
+    "from ragaai_catalyst import trace_tool\n",
     "\n",
     "catalyst = RagaAICatalyst(\n",
     "    access_key=os.getenv(\"RAGAAI_CATALYST_ACCESS_KEY\"),\n",


### PR DESCRIPTION
added trace_tool module from ragaai_catalyst

# Pull Request Template

## Description
On testing this example , there was missing import of tracel_tool , so imported it.
